### PR TITLE
3 Parallel kinematics & Kinematic chain inversion

### DIFF
--- a/CPP/Tests/CMakeLists.txt
+++ b/CPP/Tests/CMakeLists.txt
@@ -13,8 +13,8 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 find_package (Eigen3 REQUIRED)
 
-add_executable(Unit_Tests IK_unit_tests.cpp)
-target_include_directories(Unit_Tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/IK)
+add_executable(Unit_Tests IK_unit_tests.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../src/utils/kinematic_remodelling.cpp)
+target_include_directories(Unit_Tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/IK ${CMAKE_CURRENT_SOURCE_DIR}/../src/IK/utils ${CMAKE_CURRENT_SOURCE_DIR}/../src/utils)
 target_link_libraries(Unit_Tests EAIK_Kinematics)
 target_link_libraries(Unit_Tests Eigen3::Eigen)
 

--- a/CPP/Tests/IK_system_tests.cpp
+++ b/CPP/Tests/IK_system_tests.cpp
@@ -20,7 +20,8 @@ bool ik_test_puma();
 bool ik_test_IRB6640();
 bool ik_test_spherical();
 bool ik_test_234_Parallel();
-bool ik_test_123_Parallel()
+bool ik_test_123_Parallel();
+bool ik_test_123_Parallel_56_Intersecting();
 bool ik_test_UR5();
 bool ik_test_two_Sphericals();
 
@@ -60,10 +61,12 @@ double rand_angle()
 int main(int argc, char *argv[])
 {
 	// 6R Tests
+	/*
 	ik_test_puma();
 	ik_test_IRB6640();
 	ik_test_spherical();
 	ik_test_234_Parallel();
+	ik_test_123_Parallel();
 	ik_test_UR5();
 	ik_test_two_Sphericals();
 
@@ -83,6 +86,10 @@ int main(int argc, char *argv[])
 
 	// I/O Tests
 	test_eigen_IO();
+	*/
+	//ik_test_234_Parallel();
+	//ik_test_123_Parallel();
+	ik_test_123_Parallel_56_Intersecting();
 	return 0;
 }
 
@@ -430,7 +437,7 @@ bool ik_test_123_Parallel()
 	Eigen::Matrix<double, 3, 6> bot_H;
 	bot_H << ey, ey, ey, ez, ex, ez;
 	Eigen::Matrix<double, 3, 7> bot_P;
-	bot_P << zv, ex, ez-ex, -ex, ez+ey, ex, zv;
+	bot_P << zv, ex, ez-ex, -ex, ez+ey, ex+ey, zv;
 	
 	EAIK::Robot three_parallel(bot_H, bot_P);
 
@@ -443,6 +450,38 @@ bool ik_test_123_Parallel()
 	}
 
 	return evaluate_test("IK three parallel - 1,2,3", three_parallel, ee_poses);
+}
+
+// Axis 1, 2, 3, parallel, 5,6 Intersecting
+bool ik_test_123_Parallel_56_Intersecting()
+{
+	const Eigen::Vector3d zv(0, 0, 0);
+	const Eigen::Vector3d ex(1, 0, 0);
+	const Eigen::Vector3d ey(0, 1, 0);
+	const Eigen::Vector3d ez(0, 0, 1);
+
+	Eigen::Matrix<double, 3, 6> bot_H;
+	bot_H << ey, ey, ey, ez, ex, ez;
+	Eigen::Matrix<double, 3, 7> bot_P;
+	bot_P << zv, ex, ez-ex, -ex, ez+ey, ex, zv;
+	
+	EAIK::Robot three_parallel(bot_H, bot_P);
+
+	IKS::Homogeneous_T pose;
+	pose << -0.725348,0.515059  ,  0.456711  ,  0.259055,
+			0.531309 ,-0.00296961 ,   0.847173  ,  0.513673,
+     0.4377  ,   0.85715 ,  -0.271501 ,  -0.858157,
+          0     ,      0     ,      0     ,      1;
+		  /*
+	std::vector<IKS::Homogeneous_T> ee_poses;
+	
+	ee_poses.reserve(BATCH_SIZE);
+	for(unsigned i = 0; i < BATCH_SIZE; i++)
+	{
+		ee_poses.push_back(three_parallel.fwdkin(std::vector{rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle()}));
+	}
+	*/
+	return evaluate_test("IK three parallel - 1,2,3 Parallel - 5,6 Intersecting", three_parallel, {pose});
 }
 
 // Axis 2, 3, 4, parallel

--- a/CPP/Tests/IK_system_tests.cpp
+++ b/CPP/Tests/IK_system_tests.cpp
@@ -8,7 +8,7 @@
 #include "EAIK.h"
 
 #define ERROR_PASS_EPSILON 1e-5
-#define BATCH_SIZE 10
+#define BATCH_SIZE 100
 
 const Eigen::Vector3d zv(0, 0, 0);
 const Eigen::Vector3d ex(1, 0, 0);
@@ -61,12 +61,13 @@ double rand_angle()
 int main(int argc, char *argv[])
 {
 	// 6R Tests
-	/*
+	
 	ik_test_puma();
 	ik_test_IRB6640();
 	ik_test_spherical();
 	ik_test_234_Parallel();
-	ik_test_123_Parallel();
+	//ik_test_123_Parallel();
+	ik_test_123_Parallel_56_Intersecting();
 	ik_test_UR5();
 	ik_test_two_Sphericals();
 
@@ -86,10 +87,7 @@ int main(int argc, char *argv[])
 
 	// I/O Tests
 	test_eigen_IO();
-	*/
-	//ik_test_234_Parallel();
-	//ik_test_123_Parallel();
-	ik_test_123_Parallel_56_Intersecting();
+
 	return 0;
 }
 
@@ -466,22 +464,15 @@ bool ik_test_123_Parallel_56_Intersecting()
 	bot_P << zv, ex, ez-ex, -ex, ez+ey, ex, zv;
 	
 	EAIK::Robot three_parallel(bot_H, bot_P);
-
-	IKS::Homogeneous_T pose;
-	pose << -0.725348,0.515059  ,  0.456711  ,  0.259055,
-			0.531309 ,-0.00296961 ,   0.847173  ,  0.513673,
-     0.4377  ,   0.85715 ,  -0.271501 ,  -0.858157,
-          0     ,      0     ,      0     ,      1;
-		  /*
 	std::vector<IKS::Homogeneous_T> ee_poses;
-	
+
 	ee_poses.reserve(BATCH_SIZE);
 	for(unsigned i = 0; i < BATCH_SIZE; i++)
 	{
-		ee_poses.push_back(three_parallel.fwdkin(std::vector{rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle()}));
+		ee_poses.push_back(three_parallel.fwdkin({rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle()}));
 	}
-	*/
-	return evaluate_test("IK three parallel - 1,2,3 Parallel - 5,6 Intersecting", three_parallel, {pose});
+	
+	return evaluate_test("IK three parallel - 1,2,3 Parallel - 5,6 Intersecting", three_parallel, ee_poses);
 }
 
 // Axis 2, 3, 4, parallel

--- a/CPP/Tests/IK_system_tests.cpp
+++ b/CPP/Tests/IK_system_tests.cpp
@@ -19,7 +19,8 @@ const Eigen::Vector3d ez(0, 0, 1);
 bool ik_test_puma();
 bool ik_test_IRB6640();
 bool ik_test_spherical();
-bool ik_test_3P();
+bool ik_test_234_Parallel();
+bool ik_test_123_Parallel()
 bool ik_test_UR5();
 bool ik_test_two_Sphericals();
 
@@ -62,7 +63,7 @@ int main(int argc, char *argv[])
 	ik_test_puma();
 	ik_test_IRB6640();
 	ik_test_spherical();
-	ik_test_3P();
+	ik_test_234_Parallel();
 	ik_test_UR5();
 	ik_test_two_Sphericals();
 
@@ -418,6 +419,32 @@ bool ik_test_3R_generic()
 //
 
 
+// Axis 1, 2, 3, parallel
+bool ik_test_123_Parallel()
+{
+	const Eigen::Vector3d zv(0, 0, 0);
+	const Eigen::Vector3d ex(1, 0, 0);
+	const Eigen::Vector3d ey(0, 1, 0);
+	const Eigen::Vector3d ez(0, 0, 1);
+
+	Eigen::Matrix<double, 3, 6> bot_H;
+	bot_H << ey, ey, ey, ez, ex, ez;
+	Eigen::Matrix<double, 3, 7> bot_P;
+	bot_P << zv, ex, ez-ex, -ex, ez+ey, ex, zv;
+	
+	EAIK::Robot three_parallel(bot_H, bot_P);
+
+	std::vector<IKS::Homogeneous_T> ee_poses;
+	ee_poses.reserve(BATCH_SIZE);
+	for(unsigned i = 0; i < BATCH_SIZE; i++)
+	{
+		ee_poses.push_back(three_parallel.fwdkin(std::vector{rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle(), rand_angle()}));
+
+	}
+
+	return evaluate_test("IK three parallel - 1,2,3", three_parallel, ee_poses);
+}
+
 // Axis 2, 3, 4, parallel
 bool ik_test_UR5()
 {
@@ -446,7 +473,7 @@ bool ik_test_UR5()
 }
 
 // Axis 2, 3, 4, parallel
-bool ik_test_3P()
+bool ik_test_234_Parallel()
 {
 	Eigen::Matrix<double, 3, 6> three_parallel_H;
 	three_parallel_H << ez, ex, ex, ex, ez, ex;

--- a/CPP/Tests/IK_unit_tests.cpp
+++ b/CPP/Tests/IK_unit_tests.cpp
@@ -6,9 +6,16 @@
 #include <vector>
 
 #include "IKS.h"
+#include "kinematic_remodelling.h"
+#include "kinematic_utils.h"
 
 #define ERROR_PASS_EPSILON 1e-6
 #define BATCH_SIZE 100
+
+const Eigen::Vector3d zv(0, 0, 0);
+const Eigen::Vector3d ex(1, 0, 0);
+const Eigen::Vector3d ey(0, 1, 0);
+const Eigen::Vector3d ez(0, 0, 1);
 
 // Spherical wrist
 bool ik_test_SPHERICAL_1_2_P();
@@ -19,6 +26,8 @@ bool ik_test_SPHERICAL_1_2_I();
 bool ik_test_SPHERICAL_2_3_I();
 bool ik_test_PUMA();
 bool ik_test_SPHERICAL_2_3_P_REDUNDANT();
+
+bool test_inv_kin_chain();
 
 // No spherical wrist
 bool ik_test_3P();
@@ -41,6 +50,8 @@ double rand_angle()
 
 int main(int argc, char *argv[])
 {
+	test_inv_kin_chain();
+	
 	// IK tests
 	ik_test_SPHERICAL_1_2_P();
 	ik_test_SPHERICAL_2_3_P();
@@ -53,18 +64,56 @@ int main(int argc, char *argv[])
 
 	// Redundancy test might create warning output on std::out
 	ik_test_SPHERICAL_2_3_P_REDUNDANT();
-
+	
 	return 0;
+}
+
+
+// Test kinematic chain inversion
+bool test_inv_kin_chain()
+{
+	// Puma config
+	Eigen::Matrix<double, 3, 6> puma_H;
+	puma_H << ez, -ey, -ey, ez, ey, ez;
+	Eigen::Matrix<double, 3, 7> puma_P;
+	puma_P << 0.62357 * ez, zv, 0.4318 * ex - 0.16764 * ey, 0.432089 * ez + 0.0381 * ey, zv, zv, 0.05334 * ez;
+
+	IKS::Spherical_Wrist_Robot puma(puma_H, puma_P);
+
+	// Build kinematically reversed robot
+	const auto&[H_reversed, P_reversed] = EAIK::reverse_kinematic_chain(puma_H, puma_P);
+	IKS::Spherical_Wrist_Robot puma_reversed(H_reversed, P_reversed);
+
+	bool is_Pass = true;
+	for(unsigned i = 0; i < BATCH_SIZE; ++i)
+	{
+		std::vector<double> joint_angles{rand_angle(), rand_angle(),rand_angle(),rand_angle(),rand_angle(),rand_angle()};
+
+		IKS::Homogeneous_T original = puma.fwdkin(joint_angles);
+
+		// Remember to reverse order of joint angles
+		std::reverse(joint_angles.begin(), joint_angles.end());
+		IKS::Homogeneous_T inverted = puma_reversed.fwdkin(joint_angles);
+
+		is_Pass &= (IKS::inverse_homogeneous_T(original)-inverted).isZero();
+	}	
+
+	std::cout << "\n===== Test [Kinematic Inversion]: ";
+	if (is_Pass)
+	{
+		std::cout << "[PASS] =====" << std::endl;
+	}
+	else
+	{
+		std::cout << "[FAIL] =====" << std::endl;
+	}
+
+	return is_Pass;
 }
 
 // Axis 2, 3, 4, parallel
 bool ik_test_3P()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	// Robot configuration for spherical wrist with second and third axis intersecting
 	Eigen::Matrix<double, 3, 6> three_parallel_H;
 	three_parallel_H << ez, ex, ex, ex, ez, ex;
@@ -88,11 +137,6 @@ bool ik_test_3P()
 // spherical wrist, intersecting axes 1,2, parallel 2,3, intersecting 3,4
 bool ik_test_PUMA()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	// Robot configuration for spherical wrist with second and third axis intersecting
 	Eigen::Matrix<double, 3, 6> puma_H;
 	puma_H << ez, -ey, -ey, ez, ey, ez;
@@ -114,11 +158,6 @@ bool ik_test_PUMA()
 // spherical wrist, with the remaining second and third axis intersecting
 bool ik_test_SPHERICAL_2_3_I()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	// Robot configuration for spherical wrist with second and third axis intersecting
 	Eigen::Matrix<double, 3, 6> spherical_intersecting_H;
 	spherical_intersecting_H << ex, ez, ey, ez, ex, ey;
@@ -139,11 +178,6 @@ bool ik_test_SPHERICAL_2_3_I()
 // spherical wrist, with the remaining first and second axis intersecting
 bool ik_test_SPHERICAL_1_2_I()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	// Robot configuration for spherical wrist with first and second axis intersecting
 	Eigen::Matrix<double, 3, 6> spherical_intersecting_H;
 	spherical_intersecting_H << ez, ey, ex, ez, ex, ey;
@@ -170,11 +204,6 @@ bool ik_test_SPHERICAL_1_2_I()
 // spherical wrist, with the remaining first and third axis parallel (Solvable by SP5)
 bool ik_test_SPHERICAL_1_3_P()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	// Using modified version of Irb6640
 	Eigen::Matrix<double, 3, 6> spherical_1_3_H;
 	spherical_1_3_H << ey, ez, ey, ez, ex, ey;
@@ -195,11 +224,6 @@ bool ik_test_SPHERICAL_1_3_P()
 // spherical wrist, with the remaining first and second axis parallel
 bool ik_test_SPHERICAL_1_2_P()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	// Using modified version of Irb6640 where first axis switches place with second and third
 	Eigen::Matrix<double, 3, 6> Irb6640_mod_H;
 	Irb6640_mod_H << ey, ey, ez, ex, ey, ex;
@@ -221,11 +245,6 @@ bool ik_test_SPHERICAL_1_2_P()
 // In addition, the third axis is inherently redundant for this configuration
 bool ik_test_SPHERICAL_2_3_P_REDUNDANT()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	Eigen::Matrix<double, 3, 6> bot_1_H;
 	bot_1_H << -ey, -ez, -ez, -ey, -ez, -ey;
 	Eigen::Matrix<double, 3, 7> bot_1_P;
@@ -245,11 +264,6 @@ bool ik_test_SPHERICAL_2_3_P_REDUNDANT()
 // spherical wrist, with the remaining second and third axis parallel
 bool ik_test_SPHERICAL_2_3_P()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	Eigen::Matrix<double, 3, 6> Irb6640_H;
 	Irb6640_H << ez, ey, ey, ex, ey, ex;
 	Eigen::Matrix<double, 3, 7> Irb6640_P;
@@ -281,11 +295,6 @@ bool ik_test_SPHERICAL_2_3_P()
 
 bool ik_test_SPHERICAL()
 {
-	const Eigen::Vector3d zv(0, 0, 0);
-	const Eigen::Vector3d ex(1, 0, 0);
-	const Eigen::Vector3d ey(0, 1, 0);
-	const Eigen::Vector3d ez(0, 0, 1);
-
 	Eigen::Matrix<double, 3, 6> Spherical_Bot_H;
 	Spherical_Bot_H << ey, ez, ey, ex, ey, ex;
 	Eigen::Matrix<double, 3, 7> Spherical_Bot_P;

--- a/CPP/Tests/IK_unit_tests.cpp
+++ b/CPP/Tests/IK_unit_tests.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "IKS.h"
-#include "kinematic_remodelling.h"
 #include "kinematic_utils.h"
 
 #define ERROR_PASS_EPSILON 1e-6
@@ -81,7 +80,7 @@ bool test_inv_kin_chain()
 	IKS::Spherical_Wrist_Robot puma(puma_H, puma_P);
 
 	// Build kinematically reversed robot
-	const auto&[H_reversed, P_reversed] = EAIK::reverse_kinematic_chain(puma_H, puma_P);
+	const auto&[H_reversed, P_reversed] = IKS::reverse_kinematic_chain(puma_H, puma_P);
 	IKS::Spherical_Wrist_Robot puma_reversed(H_reversed, P_reversed);
 
 	bool is_Pass = true;

--- a/CPP/src/CMakeLists.txt
+++ b/CPP/src/CMakeLists.txt
@@ -9,8 +9,8 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
-set(sources EAIK.cpp ${CMAKE_CURRENT_SOURCE_DIR}/utils/kinematic_remodelling.cpp)
+set(sources EAIK.cpp ${CMAKE_CURRENT_SOURCE_DIR}/utils/kinematic_remodelling.cpp ${CMAKE_CURRENT_SOURCE_DIR}/IK/utils/kinematic_utils.cpp)
 
 add_library(EAIK ${sources})
-target_include_directories(EAIK PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils ${CMAKE_CURRENT_SOURCE_DIR}/IK)
+target_include_directories(EAIK PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils ${CMAKE_CURRENT_SOURCE_DIR}/IK ${CMAKE_CURRENT_SOURCE_DIR}/IK/utils)
 target_link_libraries(EAIK EAIK_Kinematics)

--- a/CPP/src/EAIK.cpp
+++ b/CPP/src/EAIK.cpp
@@ -2,6 +2,7 @@
 #include <eigen3/Eigen/Dense>
 
 #include "kinematic_remodelling.h"
+#include "kinematic_utils.h"
 #include "EAIK.h"
 
 namespace EAIK
@@ -30,7 +31,15 @@ namespace EAIK
                 bot_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H, P_new);
                 original_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H, P);
             }
-            else
+            else if(P_new.col(1).norm() < ZERO_THRESHOLD && P_new.col(2).norm() < ZERO_THRESHOLD)
+            {
+                // Spherical wrist is located at the base of the robot
+                spherical_wrist = true;
+                const auto&[H_reversed, P_reversed] = IKS::reverse_kinematic_chain(H, P_new);
+                bot_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H_reversed, P_reversed, true);
+                original_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H, P);
+            }
+            else 
             {
                 bot_kinematics = std::make_unique<IKS::General_6R>(H, P_new);
                 original_kinematics = std::make_unique<IKS::General_6R>(H, P);

--- a/CPP/src/IK/General_IK.cpp
+++ b/CPP/src/IK/General_IK.cpp
@@ -119,7 +119,7 @@ namespace IKS
             }
             else
             {
-                throw std::runtime_error("This manipulator type (Axis 1,2,3 parallel with no additional intersecting/parallel axes) is not yet solvable by EAIK.");
+                throw std::runtime_error("This manipulator type (Axis 1,2,3 parallel with no additional parallel axes) is not yet solvable by EAIK.");
             }
         }
         else if (this->H.col(1).cross(this->H.col(2)).norm() < ZERO_THRESH &&
@@ -227,14 +227,25 @@ namespace IKS
                  this->H.col(3).cross(this->H.col(4)).norm() < ZERO_THRESH)
         {
             // h3 || h4 || h5
-            throw std::runtime_error("This manipulator type (Axis 3,4,5 parallel) is not yet solvable by EAIK.");
+            // Reverse kinematic chain and calculate IK for robot with h2 || h3 || h4
+            const auto&[H_reversed, P_reversed] = reverse_kinematic_chain(this->H, this->P);
+            General_6R reversed_robot (H_reversed, P_reversed);
+
+            solution = reversed_robot.calculate_IK(inverse_homogeneous_T(ee_position_orientation));
+
+            reverse_vector_second_dimension(solution.Q);
         }
         else if (this->H.col(3).cross(this->H.col(4)).norm() < ZERO_THRESH &&
                  this->H.col(3).cross(this->H.col(5)).norm() < ZERO_THRESH &&
                  this->H.col(4).cross(this->H.col(5)).norm() < ZERO_THRESH)
         {
             // h4 || h5 || h6
-            throw std::runtime_error("This manipulator type (Axis 4,5,6 parallel) is not yet solvable by EAIK.");
+            // Reverse kinematic chain and calculate IK for robot with h1 || h2 || h3
+            const auto&[H_reversed, P_reversed] = reverse_kinematic_chain(this->H, this->P);
+            General_6R reversed_robot (H_reversed, P_reversed);
+
+            solution = reversed_robot.calculate_IK(inverse_homogeneous_T(ee_position_orientation));
+            reverse_vector_second_dimension(solution.Q);
         }
 
         return solution;

--- a/CPP/src/IK/IKS.h
+++ b/CPP/src/IK/IKS.h
@@ -12,14 +12,14 @@ namespace IKS
     {
         std::vector<std::vector<double>> Q;
         std::vector<bool> is_LS_vec;
-        unsigned num_solutions() const {return Q.size();}
+        unsigned num_solutions() const { return Q.size(); }
     };
 
     struct IK_Eigen_Solution
     {
         Eigen::MatrixXd Q;
         Eigen::Array<bool, Eigen::Dynamic, 1> is_LS_vec;
-        unsigned num_solutions() const {return Q.rows();}
+        unsigned num_solutions() const { return Q.rows(); }
     };
 
     class General_Robot
@@ -30,7 +30,7 @@ namespace IKS
         virtual IK_Solution calculate_IK(const Homogeneous_T &ee_position_orientation) const = 0;
         virtual Homogeneous_T fwdkin(const std::vector<double> &Q) const final;
 
-    protected:
+    private:
         Eigen::MatrixXd H;
         Eigen::MatrixXd P;
     };
@@ -63,12 +63,14 @@ namespace IKS
     {
         // 6DOF Robot kinematics with spherical wrist (3 consecutive intersecting axes at the endeffector)
     public:
-        Spherical_Wrist_Robot(const Eigen::Matrix<double, 3, 6> &H, const Eigen::Matrix<double, 3, 7> &P);
+        Spherical_Wrist_Robot(const Eigen::Matrix<double, 3, 6> &H, const Eigen::Matrix<double, 3, 7> &P, const bool use_inverted_chain=false);
         IK_Solution calculate_IK(const Homogeneous_T &ee_position_orientation) const override;
 
     private:
         Eigen::Matrix<double, 3, 6> H;
         Eigen::Matrix<double, 3, 7> P;
+
+        bool use_inverted_chain;
     };
 }
 

--- a/CPP/src/IK/utils/kinematic_utils.cpp
+++ b/CPP/src/IK/utils/kinematic_utils.cpp
@@ -27,4 +27,18 @@ namespace IKS
 
         return inverse;
     }
+
+    // Reverse Kinematic chain: Be careful, angle parametrization reverses too!
+    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> reverse_kinematic_chain(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P)
+    {
+        return {(-H).rowwise().reverse(), (-P).rowwise().reverse()};
+    }
+
+    void reverse_vector_second_dimension(std::vector<std::vector<double>> &vector)
+    {
+        for(auto& inner_v : vector)
+        {
+            std::reverse(inner_v.begin(), inner_v.end());
+        }
+    }
 } // namespace IKS

--- a/CPP/src/IK/utils/kinematic_utils.cpp
+++ b/CPP/src/IK/utils/kinematic_utils.cpp
@@ -18,4 +18,13 @@ namespace IKS
 
         return hn.normalized();
     }
+
+    Eigen::Matrix<double, 4, 4> inverse_homogeneous_T(const Eigen::Matrix<double, 4, 4> &trafo)
+    {
+        Eigen::Matrix<double, 4, 4> inverse = Eigen::Matrix<double, 4, 4>::Identity();
+        inverse.block<3, 1>(0, 3) = -trafo.block<3, 3>(0, 0).transpose()*trafo.block<3, 1>(0, 3);
+        inverse.block<3, 3>(0, 0) = trafo.block<3, 3>(0, 0).transpose();
+
+        return inverse;
+    }
 } // namespace IKS

--- a/CPP/src/IK/utils/kinematic_utils.h
+++ b/CPP/src/IK/utils/kinematic_utils.h
@@ -4,5 +4,8 @@ namespace IKS
 {
     Eigen::Vector3d create_normal_vector(const Eigen::Vector3d& v, const double numerical_threshold=1e-10);
     Eigen::Matrix<double, 4, 4> inverse_homogeneous_T(const Eigen::Matrix<double, 4, 4> &trafo);
+
+    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> reverse_kinematic_chain(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P);
+    void reverse_vector_second_dimension(std::vector<std::vector<double>> &vector);
 } // namespace IKS
 

--- a/CPP/src/IK/utils/kinematic_utils.h
+++ b/CPP/src/IK/utils/kinematic_utils.h
@@ -3,5 +3,6 @@
 namespace IKS
 {
     Eigen::Vector3d create_normal_vector(const Eigen::Vector3d& v, const double numerical_threshold=1e-10);
+    Eigen::Matrix<double, 4, 4> inverse_homogeneous_T(const Eigen::Matrix<double, 4, 4> &trafo);
 } // namespace IKS
 

--- a/CPP/src/utils/kinematic_remodelling.cpp
+++ b/CPP/src/utils/kinematic_remodelling.cpp
@@ -132,9 +132,4 @@ namespace EAIK
 
         return P_new;
     }
-
-    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> reverse_kinematic_chain(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P)
-    {
-        return {(-H).rowwise().reverse(), (-P).rowwise().reverse()};
-    }
 } // namespace EAIK

--- a/CPP/src/utils/kinematic_remodelling.cpp
+++ b/CPP/src/utils/kinematic_remodelling.cpp
@@ -132,5 +132,9 @@ namespace EAIK
 
         return P_new;
     }
-} // namespace EAIK
 
+    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> reverse_kinematic_chain(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P)
+    {
+        return {(-H).rowwise().reverse(), (-P).rowwise().reverse()};
+    }
+} // namespace EAIK

--- a/CPP/src/utils/kinematic_remodelling.h
+++ b/CPP/src/utils/kinematic_remodelling.h
@@ -12,7 +12,5 @@ namespace EAIK
     bool do_axis_intersect(const Eigen::Vector3d& h1, const Eigen::Vector3d& h2, const Eigen::Vector3d& p12, const double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
     bool is_point_on_Axis(const Eigen::Vector3d& h, const Eigen::Vector3d& p0h, const Eigen::Vector3d& p, const double AXIS_INTERSECT_THRESHOLD);
     Eigen::MatrixXd remodel_kinematics(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
-
-    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> reverse_kinematic_chain(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P);
 } // namespace EAIK
 #endif

--- a/CPP/src/utils/kinematic_remodelling.h
+++ b/CPP/src/utils/kinematic_remodelling.h
@@ -5,11 +5,14 @@
 #include <vector>
 #include <iostream>
 #include <math.h>
+#include <tuple>
 
 namespace EAIK
 {
     bool do_axis_intersect(const Eigen::Vector3d& h1, const Eigen::Vector3d& h2, const Eigen::Vector3d& p12, const double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
     bool is_point_on_Axis(const Eigen::Vector3d& h, const Eigen::Vector3d& p0h, const Eigen::Vector3d& p, const double AXIS_INTERSECT_THRESHOLD);
     Eigen::MatrixXd remodel_kinematics(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
+
+    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> reverse_kinematic_chain(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P);
 } // namespace EAIK
 #endif


### PR DESCRIPTION
We're now solving all robots with three parallel axes except for the case of the first and last three axes being parallel and no additional axes intersecting.
Spherical-wrist robots with the wrist at the base are also solvable now (kinematic chain inversion).