### PR TITLE
Support for Ndof by joint locking

### DIFF
--- a/CPP/src/EAIK.cpp
+++ b/CPP/src/EAIK.cpp
@@ -139,7 +139,7 @@ namespace EAIK
     // Eigen matrices as solutions for the pybindings
     IKS::IK_Eigen_Solution Robot::calculate_Eigen_IK(const IKS::Homogeneous_T &ee_position_orientation) const
     {
-        IKS::IK_Solution vector_solution = bot_kinematics->calculate_IK(ee_position_orientation);
+        IKS::IK_Solution vector_solution = calculate_IK(ee_position_orientation);
         IKS::IK_Eigen_Solution eigen_solution;
 
         if(vector_solution.Q.size() > 0)

--- a/CPP/src/EAIK.cpp
+++ b/CPP/src/EAIK.cpp
@@ -9,7 +9,7 @@
 
 namespace EAIK
 {
-    Robot::Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, const std::vector<std::pair<int, double>>& fixed_axes, bool is_double_precision)
+    Robot::Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, const Eigen::Matrix<double, 3, 3> R6T, const std::vector<std::pair<int, double>>& fixed_axes, bool is_double_precision) : R6T(R6T)
     {
         if(is_double_precision)
         {
@@ -22,42 +22,55 @@ namespace EAIK
             throw std::runtime_error("Wrong input dimensions for H and P. Note that #P = #H+1.");
         }
 
-        // Insert fixed axes into the kinematic chain
+        Eigen::MatrixXd P_remodelled;
+        Eigen::MatrixXd H_remodelled;
+
+        // Insert fixed axes (e.g., to cope with >6DOF manipulators) into the kinematic chain
         if(fixed_axes.size()>0)
         {
-            
+            this->fixed_axes = fixed_axes;
+            std::sort(this->fixed_axes.begin(), this->fixed_axes.end(), [](const std::pair<int, double>& a, const std::pair<int, double>& b) {return a.first < b.first;});
+
+            const auto&[H_part, P_part, R6T_part] = partial_joint_parametrization(H, P, fixed_axes, R6T);
+            P_remodelled = remodel_kinematics(H_part, P_part, ZERO_THRESHOLD, AXIS_INTERSECT_THRESHOLD);
+            H_remodelled = H_part;
+            this->R6T_partial = R6T_part;
+        }
+        else
+        {
+            P_remodelled = remodel_kinematics(H, P, ZERO_THRESHOLD, AXIS_INTERSECT_THRESHOLD);
+            H_remodelled = H;
+            this->R6T_partial = R6T;
         }
 
-        Eigen::MatrixXd P_new = remodel_kinematics(H, P, ZERO_THRESHOLD, AXIS_INTERSECT_THRESHOLD);
-
-        switch (H.cols())
+        switch (H_remodelled.cols())
         {
         case 6:
             // Check if last three axes intersect
-            if (P_new.col(P_new.cols()-3).norm() < ZERO_THRESHOLD && P_new.col(P_new.cols()-2).norm() < ZERO_THRESHOLD)
+            if (P_remodelled.col(P_remodelled.cols()-3).norm() < ZERO_THRESHOLD && P_remodelled.col(P_remodelled.cols()-2).norm() < ZERO_THRESHOLD)
             {   
                 spherical_wrist = true;
-                bot_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H, P_new);
-                original_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H, P);
+                bot_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H_remodelled, P_remodelled);
+                original_kinematics = std::make_unique<IKS::General_Robot>(H, P);
             }
-            else if(P_new.col(1).norm() < ZERO_THRESHOLD && P_new.col(2).norm() < ZERO_THRESHOLD)
+            else if(P_remodelled.col(1).norm() < ZERO_THRESHOLD && P_remodelled.col(2).norm() < ZERO_THRESHOLD)
             {
                 // Spherical wrist is located at the base of the robot
                 spherical_wrist = true;
-                const auto&[H_reversed, P_reversed] = IKS::reverse_kinematic_chain(H, P_new);
+                const auto&[H_reversed, P_reversed] = IKS::reverse_kinematic_chain(H_remodelled, P_remodelled);
                 bot_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H_reversed, P_reversed, true);
-                original_kinematics = std::make_unique<IKS::Spherical_Wrist_Robot>(H, P);
+                original_kinematics = std::make_unique<IKS::General_Robot>(H, P);
             }
             else 
             {
-                bot_kinematics = std::make_unique<IKS::General_6R>(H, P_new);
-                original_kinematics = std::make_unique<IKS::General_6R>(H, P);
+                bot_kinematics = std::make_unique<IKS::General_6R>(H_remodelled, P_remodelled);
+                original_kinematics = std::make_unique<IKS::General_Robot>(H, P);
             }
             break;
         
         case 3:
-                bot_kinematics = std::make_unique<IKS::General_3R>(H, P_new);
-                original_kinematics = std::make_unique<IKS::General_3R>(H, P);  
+                bot_kinematics = std::make_unique<IKS::General_3R>(H_remodelled, P_remodelled);
+                original_kinematics = std::make_unique<IKS::General_Robot>(H, P);  
             break;
         default:
             throw std::runtime_error("Currently, only 6R and 3R Robots are solvable with EAIK.");
@@ -67,7 +80,20 @@ namespace EAIK
 
     IKS::IK_Solution Robot::calculate_IK(const IKS::Homogeneous_T &ee_position_orientation) const
     {
-        return bot_kinematics->calculate_IK(ee_position_orientation);
+        IKS::Homogeneous_T ee_06_rot = ee_position_orientation;
+        ee_06_rot.block<3,3>(0,0) *= R6T_partial.transpose();
+        IKS::IK_Solution solution = bot_kinematics->calculate_IK(ee_06_rot);
+
+        // TODO: Find alternative to this costly insert operation
+        for(const auto&[joint_index, value] : fixed_axes)
+        {
+            for(auto& Qs : solution.Q)
+            {
+                Qs.insert(Qs.begin()+joint_index, value);
+            }
+        }
+
+        return solution;
     }    
     
     std::vector<IKS::IK_Solution> Robot::calculate_IK_batched(std::vector<IKS::Homogeneous_T> EE_pose_batch, const unsigned worker_threads) const
@@ -177,7 +203,9 @@ namespace EAIK
 
     IKS::Homogeneous_T Robot::fwdkin(const std::vector<double> &Q) const
     {
-        return original_kinematics->fwdkin(Q);
+        IKS::Homogeneous_T sol_r06 = original_kinematics->fwdkin(Q);
+        sol_r06.block<3,3>(0,0) *= R6T;
+        return sol_r06;
     }
 
     // Function for use with pybindings and the corresponding numpy arrays

--- a/CPP/src/EAIK.cpp
+++ b/CPP/src/EAIK.cpp
@@ -9,7 +9,7 @@
 
 namespace EAIK
 {
-    Robot::Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, bool is_double_precision)
+    Robot::Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, const std::vector<std::pair<int, double>>& fixed_axes, bool is_double_precision)
     {
         if(is_double_precision)
         {
@@ -17,11 +17,18 @@ namespace EAIK
             AXIS_INTERSECT_THRESHOLD = 1e-9;
         }
 
-        Eigen::MatrixXd P_new = remodel_kinematics(H, P, ZERO_THRESHOLD, AXIS_INTERSECT_THRESHOLD);
         if(P.cols() != H.cols() + 1)
         {
             throw std::runtime_error("Wrong input dimensions for H and P. Note that #P = #H+1.");
         }
+
+        // Insert fixed axes into the kinematic chain
+        if(fixed_axes.size()>0)
+        {
+            
+        }
+
+        Eigen::MatrixXd P_new = remodel_kinematics(H, P, ZERO_THRESHOLD, AXIS_INTERSECT_THRESHOLD);
 
         switch (H.cols())
         {

--- a/CPP/src/EAIK.h
+++ b/CPP/src/EAIK.h
@@ -12,7 +12,7 @@ namespace EAIK
     class Robot
     {
     public:
-        Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, const std::vector<std::pair<int, double>>& fixed_axes={}, bool is_double_precision=true);
+        Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, const Eigen::Matrix<double, 3, 3> R6T=Eigen::Matrix<double, 3, 3>::Identity(), const std::vector<std::pair<int, double>>& fixed_axes={}, bool is_double_precision=true);
         IKS::IK_Solution calculate_IK(const IKS::Homogeneous_T &ee_position_orientation) const;
         std::vector<IKS::IK_Solution> calculate_IK_batched(std::vector<IKS::Homogeneous_T> EE_pose_batch, const unsigned worker_threads) const;
 
@@ -31,6 +31,10 @@ namespace EAIK
         // single precision default thresholds
         double ZERO_THRESHOLD = 1e-7; 
         double AXIS_INTERSECT_THRESHOLD = 1e-6;
+        
+        Eigen::Matrix<double, 3, 3> R6T;
+        Eigen::Matrix<double, 3, 3> R6T_partial;
+        std::vector<std::pair<int, double>> fixed_axes; // Locked axes sorted by rising indices (!)
     };
 } // namespace EAIK
 #endif

--- a/CPP/src/EAIK.h
+++ b/CPP/src/EAIK.h
@@ -3,6 +3,7 @@
 
 #include <eigen3/Eigen/Dense>
 #include <memory>
+#include <tuple>
 
 #include "IKS.h"
 
@@ -11,7 +12,7 @@ namespace EAIK
     class Robot
     {
     public:
-        Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, bool is_double_precision=true);
+        Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, const std::vector<std::pair<int, double>>& fixed_axes={}, bool is_double_precision=true);
         IKS::IK_Solution calculate_IK(const IKS::Homogeneous_T &ee_position_orientation) const;
         std::vector<IKS::IK_Solution> calculate_IK_batched(std::vector<IKS::Homogeneous_T> EE_pose_batch, const unsigned worker_threads) const;
 

--- a/CPP/src/IK/General_IK.cpp
+++ b/CPP/src/IK/General_IK.cpp
@@ -41,6 +41,11 @@ namespace IKS
         return result;
     }
 
+    IK_Solution General_Robot::calculate_IK(const Homogeneous_T &ee_position_orientation) const
+    {
+        throw std::runtime_error("General Robot has no valid IK formulation. Use corresponding specifications for 6R/3R robots or fix joint values for redundant robots");
+    }
+
     General_6R::General_6R(const Eigen::Matrix<double, 3, 6> &H, const Eigen::Matrix<double, 3, 7> &P)
         : General_Robot(H,P), H(H), P(P)
     {

--- a/CPP/src/IK/IKS.h
+++ b/CPP/src/IK/IKS.h
@@ -27,7 +27,7 @@ namespace IKS
         // General Robot kinematics
     public:
         General_Robot(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P);
-        virtual IK_Solution calculate_IK(const Homogeneous_T &ee_position_orientation) const = 0;
+        virtual IK_Solution calculate_IK(const Homogeneous_T &ee_position_orientation) const;
         virtual Homogeneous_T fwdkin(const std::vector<double> &Q) const final;
 
     private:

--- a/CPP/src/utils/kinematic_remodelling.cpp
+++ b/CPP/src/utils/kinematic_remodelling.cpp
@@ -132,4 +132,32 @@ namespace EAIK
 
         return P_new;
     }
+
+    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> partial_joint_parametrization(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, std::vector<std::pair<int, double>> fixed_axes)
+    {
+        // Sort fixed axes parametrization to start with last axis first
+        std::sort(fixed_axes.begin(), fixed_axes.end(), [](const std::pair<int, double>& a, const std::pair<int, double>& b) {return a.first > b.first;});
+        Eigen::MatrixXd H_new = H;
+        Eigen::MatrixXd P_new = P;
+        std::cout<<H_new<<std::endl<<P_new<<std::endl;
+
+        for(const auto&[axis_index, q] : fixed_axes)
+        {
+            const Eigen::Matrix3d r_fixed = Eigen::AngleAxisd(q, H_new.col(axis_index).normalized()).toRotationMatrix();
+            P_new.col(axis_index) += r_fixed*P_new.col(axis_index+1);
+            
+            P_new.block(0, axis_index+1, 3, P_new.cols()-axis_index-2) = P_new.block(0, axis_index+2, 3, P_new.cols()-axis_index-2).eval();
+
+            H_new.col(axis_index) = r_fixed*H_new.col(axis_index+1);
+            H_new.block(0, axis_index+1, 3, H_new.cols()-axis_index-2) = H_new.block(0, axis_index+2, 3, H_new.cols()-axis_index-2).eval();
+            std::cout<<H_new<<std::endl<<P_new<<std::endl;
+
+            H_new = H_new.block(0, 0, 3, H_new.cols()-1).eval();
+            P_new = P_new.block(0, 0, 3, P_new.cols()-1).eval();
+            
+            std::cout<<H_new<<std::endl<<P_new<<std::endl;
+        }
+        
+        return {H_new, P_new};
+    }
 } // namespace EAIK

--- a/CPP/src/utils/kinematic_remodelling.h
+++ b/CPP/src/utils/kinematic_remodelling.h
@@ -14,6 +14,6 @@ namespace EAIK
     Eigen::MatrixXd remodel_kinematics(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
 
     // Create kinematic chain that implies series of fixed joint values
-    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> partial_joint_parametrization(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, std::vector<std::pair<int, double>> fixed_axes);
+    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::Matrix<double, 3, 3>> partial_joint_parametrization(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, std::vector<std::pair<int, double>> fixed_axes, const Eigen::Matrix<double, 3, 3>& R6T=Eigen::Matrix<double, 3, 3>::Identity());
 } // namespace EAIK
 #endif

--- a/CPP/src/utils/kinematic_remodelling.h
+++ b/CPP/src/utils/kinematic_remodelling.h
@@ -12,5 +12,8 @@ namespace EAIK
     bool do_axis_intersect(const Eigen::Vector3d& h1, const Eigen::Vector3d& h2, const Eigen::Vector3d& p12, const double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
     bool is_point_on_Axis(const Eigen::Vector3d& h, const Eigen::Vector3d& p0h, const Eigen::Vector3d& p, const double AXIS_INTERSECT_THRESHOLD);
     Eigen::MatrixXd remodel_kinematics(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, double ZERO_THRESHOLD, const double AXIS_INTERSECT_THRESHOLD);
+
+    // Create kinematic chain that implies series of fixed joint values
+    std::pair<Eigen::MatrixXd, Eigen::MatrixXd> partial_joint_parametrization(const Eigen::MatrixXd &H, const Eigen::MatrixXd &P, std::vector<std::pair<int, double>> fixed_axes);
 } // namespace EAIK
 #endif

--- a/src/eaik/IK_URDF.py
+++ b/src/eaik/IK_URDF.py
@@ -17,7 +17,7 @@ class Robot:
         axis_n = R.dot(axis)
         return (axis_n, T)
 
-    def __init__(self, file_path):
+    def __init__(self, file_path : str, fixed_axes : list[tuple[int, float]], use_double_precision : bool = True):
         robot = URDF.load(file_path)
         joints = robot._sort_joints(robot.actuated_joints)
 
@@ -35,7 +35,7 @@ class Robot:
 
         # Endeffector displacement is (0,0,0)
         P = np.vstack([P, np.zeros(3)])
-        self.__robot = cs.Robot(H.T, P.T,True)
+        self.__robot = cs.Robot(H.T, P.T, np.eye(3), fixed_axes, use_double_precision)
         
     def hasSphericalWrist(self):
         return self.__robot.isSpherical()

--- a/src/eaik/examples/load_urdf _7dof.py
+++ b/src/eaik/examples/load_urdf _7dof.py
@@ -1,0 +1,50 @@
+import numpy as np
+import random
+
+from eaik.IK_URDF import Robot
+import evaluate_ik as eval
+
+def test_urdf(path, batch_size):
+    """
+    Loads spherical-wrist robot from urdf, calculates IK using subproblems and checks the solution for a certian batch size
+    """
+    
+    # Lock axis 3 (index 2) at q3=2.14
+    q3 = 2.14
+    bot = Robot(path, [(2, q3)], False)
+
+    # Example desired pose
+    test_angles = []
+    for i in range(batch_size):
+        rand_angles = np.array([random.random(), random.random(), q3, random.random(), random.random(), random.random(), random.random()])
+        rand_angles *= 2*np.pi
+        test_angles.append(rand_angles)
+    poses = []
+    for angles in test_angles:
+       poses.append(bot.fwdKin(angles))
+
+    error_sum = 0
+    num_no_solution = 0
+    total_num_ls = 0
+    total_num_analytic = 0
+    for pose in poses:
+        ik_solution = bot.IK(pose)
+
+        avg_error, num_analytic, is_ls  = eval.evaluate_ik(bot, ik_solution, pose, np.eye(3))
+        if is_ls:
+            # LS solution
+            total_num_ls += 1
+            error_sum += avg_error
+        elif num_analytic > 0:
+            # Analytic solutions
+            error_sum += avg_error
+            total_num_analytic += 1
+        else:
+            num_no_solution += 1
+    if total_num_analytic + total_num_ls > 0:
+        print("Average error: ", error_sum / (total_num_analytic + total_num_ls))
+    print("Number success: ", total_num_analytic + total_num_ls)
+    print("Number failure: ", num_no_solution)
+    print("Number LS: ", total_num_ls)
+
+test_urdf("/home/daniel/Documents/lbr_iiwa7_r800-urdf-package/urdf/lbr_iiwa7_r800.urdf", 100)

--- a/src/eaik/pybindings/eaik_pybindings.cpp
+++ b/src/eaik/pybindings/eaik_pybindings.cpp
@@ -37,7 +37,16 @@ PYBIND11_MODULE(canonical_subproblems, m)
         });
 
     py::class_<EAIK::Robot>(m, "Robot")
-        .def(py::init<const Eigen::MatrixXd &, const Eigen::MatrixXd &, bool>())
+        .def(py::init<const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::Matrix<double, 3, 3> &, const std::vector<std::pair<int, double>>&, bool>(), R"pbdoc(
+            The EAIK Robot class.
+
+            :param H:  Unit vectors defining the joint axes
+            :param P:  Linear Joint offsets
+            :param R6T:  Endeffector orientation w.r.t. joint 6
+            :param fixed_axes:  List of tuples defining fixed joints (zero-indexed) (i, q_i+1)    
+            :param use_double_precision:  Use double precision (standard)
+        )pbdoc",
+        py::arg("H"), py::arg("P"), py::arg("R6T"), py::arg("fixed_axes"), py::arg("use_double_precision"))
         .def("calculate_IK", &EAIK::Robot::calculate_Eigen_IK, R"pbdoc(
             Run inverse kinematics.
 


### PR DESCRIPTION
Partial parametrization of the kinematic chain's joint values.
Enabling, e.g., solutions for 7DOF robots by "joint-locking"