### PR TITLE
Binary Wheels and Windows compatible install

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,57 @@
+name: Build Wheels
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.23
+        env:
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: universal2
+          CIBW_ARCHS_WINDOWS: AMD64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: |
+          python -m pip install build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,16 +6,28 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            cibw_arch: x86_64
+
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            cibw_arch: aarch64
+
+          - os: windows-latest
+            arch: AMD64
+            cibw_arch: AMD64
+
+          - os: macos-latest
+            arch: universal2
+            cibw_arch: universal2
 
     steps:
       - uses: actions/checkout@v4
@@ -30,13 +42,11 @@ jobs:
         uses: pypa/cibuildwheel@v2.23
         env:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_MACOS: universal2
-          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
   build_sdist:
@@ -46,6 +56,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:
@@ -42,7 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,16 +6,28 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            cibw_arch: x86_64
+
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            cibw_arch: aarch64
+
+          - os: windows-latest
+            arch: AMD64
+            cibw_arch: AMD64
+
+          - os: macos-latest
+            arch: universal2
+            cibw_arch: universal2
 
     steps:
       - uses: actions/checkout@v4
@@ -30,13 +42,11 @@ jobs:
         uses: pypa/cibuildwheel@v2.23
         env:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_MACOS: universal2
-          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+name: Build and Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.23
+        env:
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: universal2
+          CIBW_ARCHS_WINDOWS: AMD64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: |
+          python -m pip install build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    needs:
+      - build_wheels
+      - build_sdist
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - run: |
+          mkdir upload
+          find dist -type f \( -name "*.whl" -o -name "*.tar.gz" \) -exec cp {} upload/ \;
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: upload

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:
@@ -42,7 +44,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          submodules: recursive
+          
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "CPP/external/ik-geo"]
 	path = CPP/external/ik-geo
 	url = git@github.com:OstermD/ik-geo.git
+[submodule "CPP/external/eigen"]
+	path = CPP/external/eigen
+	url = https://gitlab.com/libeigen/eigen.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "CPP/external/ik-geo"]
 	path = CPP/external/ik-geo
-	url = git@github.com:OstermD/ik-geo.git
+	url = https://github.com/OstermD/ik-geo.git
 [submodule "CPP/external/eigen"]
 	path = CPP/external/eigen
 	url = https://gitlab.com/libeigen/eigen.git

--- a/CPP/Tests/IK_unit_tests.cpp
+++ b/CPP/Tests/IK_unit_tests.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <random>
 #include <vector>
 

--- a/CPP/Tests/System_Tests/1R/IK_system_tests_1R.cpp
+++ b/CPP/Tests/System_Tests/1R/IK_system_tests_1R.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 // Hacky way to access private class members for testing purposes

--- a/CPP/Tests/System_Tests/2R/IK_system_tests_2R.cpp
+++ b/CPP/Tests/System_Tests/2R/IK_system_tests_2R.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 // Hacky way to access private class members for testing purposes

--- a/CPP/Tests/System_Tests/3R/IK_system_tests_3R.cpp
+++ b/CPP/Tests/System_Tests/3R/IK_system_tests_3R.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 #include "EAIK.h"

--- a/CPP/Tests/System_Tests/4R/IK_system_tests_4R.cpp
+++ b/CPP/Tests/System_Tests/4R/IK_system_tests_4R.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 #include "EAIK.h"

--- a/CPP/Tests/System_Tests/5R/IK_system_tests_5R.cpp
+++ b/CPP/Tests/System_Tests/5R/IK_system_tests_5R.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 #include "EAIK.h"

--- a/CPP/Tests/System_Tests/6R/IK_system_tests_6R.cpp
+++ b/CPP/Tests/System_Tests/6R/IK_system_tests_6R.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <string>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 #include "EAIK.h"

--- a/CPP/Tests/Utils/IK_test_utils.h
+++ b/CPP/Tests/Utils/IK_test_utils.h
@@ -2,7 +2,7 @@
 #define IK_TEST_UTILS_H
 
 #include <vector>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include "EAIK.h"
 
 #define ERROR_PASS_EPSILON 1e-5

--- a/CPP/src/EAIK.cpp
+++ b/CPP/src/EAIK.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <thread>
 #include <mutex>
 

--- a/CPP/src/EAIK.h
+++ b/CPP/src/EAIK.h
@@ -1,7 +1,7 @@
 #ifndef EAIK_IMPL
 #define EAIK_IMPL
 
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <memory>
 #include <tuple>
 

--- a/CPP/src/IK/1R_IK.cpp
+++ b/CPP/src/IK/1R_IK.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/IK/2R_IK.cpp
+++ b/CPP/src/IK/2R_IK.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/IK/3R_IK.cpp
+++ b/CPP/src/IK/3R_IK.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/IK/4R_IK.cpp
+++ b/CPP/src/IK/4R_IK.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/IK/5R_IK.cpp
+++ b/CPP/src/IK/5R_IK.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/IK/6R_IK.cpp
+++ b/CPP/src/IK/6R_IK.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/IK/IKS.h
+++ b/CPP/src/IK/IKS.h
@@ -2,7 +2,7 @@
 #define SPHERICAL_IK_H
 
 #include <vector>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <memory>
 
 namespace IKS

--- a/CPP/src/IK/utils/kinematic_utils.cpp
+++ b/CPP/src/IK/utils/kinematic_utils.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <math.h>
 #include <iostream>
 #include "kinematic_utils.h"

--- a/CPP/src/IK/utils/kinematic_utils.h
+++ b/CPP/src/IK/utils/kinematic_utils.h
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include "IKS.h"
 
 namespace IKS

--- a/CPP/src/utils/kinematic_remodeling.cpp
+++ b/CPP/src/utils/kinematic_remodeling.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/CPP/src/utils/kinematic_remodeling.h
+++ b/CPP/src/utils/kinematic_remodeling.h
@@ -1,7 +1,7 @@
 #ifndef KINEMATIC_REMODELING
 #define KINEMATIC_REMODELING
 
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 #include <iostream>
 #include <math.h>

--- a/README.md
+++ b/README.md
@@ -73,22 +73,18 @@ The following figure shows an overview of our interface and a superficial showca
 If you require a vast amount of IK problems to be computed at once, we also implement a multithreaded batched version that allows you to make full use of your processor.
 
 ## Installation
-## Dependencies and Installation
-We use [Eigen 3.4](https://eigen.tuxfamily.org/index.php?title=Main_Page) for a fast implementation of the linear algebra operations within this toolbox.
-Make sure you have your Eigen headers placed in their standard directory ('/usr/include/eigen3', '/usr/local/include/eigen3') - otherwise the following step will not work for you.
-
-We suggest using our pip-installable [PyPI package](https://pypi.org/project/EAIK/#description). Simply use the following command on your Linux machine:
-
+### Linux
+For Linux machines, we suggest using our pip-installable [PyPI package](https://pypi.org/project/EAIK/#description):
 ```
-pip install EAIK
+$ pip install EAIK
 ```
 
 <br>
 
-If you want to directly use the C++ functionality as a library and skip the Python wrapper, simply clone our [GitHub Repository](https://github.com/OstermD/EAIK) and follow the following steps.
+If you want to directly use the C++ functionality as a library and skip the Python wrapper, simply follow the next steps.
 
 
-Make sure to clone the external dependencies of this library using:
+Make sure to clone this repository with all external dependencies using:
 ```
 $ git clone --recurse-submodules git@github.com:OstermD/EAIK.git
 ```
@@ -100,6 +96,18 @@ $ cmake ..
 $ make
 ```
 
+### Windows
+Windows is currently only supported via manual installation. 
+Make sure to clone this repository with all external dependencies using:
+```
+$ git clone --recurse-submodules git@github.com:OstermD/EAIK.git
+```
+
+Then build and install EAIK within the currently active Python environment (>=3.9):
+
+```
+$ cd EAIK && pip install .
+```
 
 ## Usage Example
 We currently provide support parametrizing a robot via DH parameters, homogeneous transformations of each joint in zero-pose with respect to the basis, as well as [ROS URDF](http://wiki.ros.org/urdf) files.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The example below is just a small code snipped. As the C++ code quickly becomes 
 The code there can also be used as an example on how you can use our library in a bigger project that, e.g., requires checks for least-square solutions etc.
 
 ```C
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <vector>
 
 #include "EAIK.h"

--- a/examples/load_urdf.py
+++ b/examples/load_urdf.py
@@ -8,13 +8,13 @@ def urdf_example(path, batch_size):
     Loads spherical-wrist robot from urdf, calculates IK using subproblems and checks the solution for a certian batch size
     """
     bot = UrdfRobot(path, [])
-    print("Kinematic Family of the Robot: ", bot.kinematicFamily())
-    print("Joint axes orientations before remodeling: \n",bot.H_original())
-    print("Joint axes' reference points before remodeling: \n", bot.P_original())
-    print("Joint axes orientations after remodeling: \n", bot.H_remodeled())
-    print("Joint axes' reference points after remodeling: \n", bot.P_remodeled())
+    print("Kinematic Family of the Robot: ", bot.getKinematicFamily())
+    print("Joint axes orientations before remodeling: \n",bot.getOriginal_H())
+    print("Joint axes' reference points before remodeling: \n", bot.getOriginal_P())
+    print("Joint axes orientations after remodeling: \n", bot.getRemodeled_H())
+    print("Joint axes' reference points after remodeling: \n", bot.getRemodeled_P())
 
-    # Example desired pose
+    # Example desired poses
     test_angles = []
     for i in range(batch_size):
         rand_angles = np.array([random.random(), random.random(), random.random(), random.random(), random.random(),random.random()])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,22 @@ skip = [
     "*-musllinux_*",
     "pp*"
 ]
+
+# Default for older Pythons
+manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+
+[[tool.cibuildwheel.overrides]]
+select = "cp311-*"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+[[tool.cibuildwheel.overrides]]
+select = "cp312-*"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+[[tool.cibuildwheel.overrides]]
+select = "cp313-*"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,13 @@ classifiers = [
 ]
 keywords = ["Analytical Inverse Kinematics", "Inverse Kinematics", "Robot Kinematics"]
 dependencies = [
-    "numpy>=2.4.6,<3",
-    "scipy>=1.17.1,<2",
-    "urchin>=0.0.30",
+  'numpy>=1.26.4,<3; python_version < "3.11"',
+  'numpy>=2.4.6,<3; python_version >= "3.11"',
+  'scipy>=1.13.1,<2; python_version < "3.11"',
+  'scipy>=1.17.1,<2; python_version >= "3.11"',
+  'urchin>=0.0.30',
 ]
+
 requires-python = ">=3.9"
 version="1.2.1"
 
@@ -30,7 +33,6 @@ Paper-Preprint = "https://arxiv.org/abs/2409.14815"
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 test-command = """
-python -m pip install --only-binary=:all: numpy scipy urchin
 python -c \"import eaik; print('OK')\"
 """
 skip = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 requires-python = ">=3.9"
-version="1.2.1"
+version="1.2.2"
 
 [project.urls]
 GitHub = "https://github.com/OstermD/EAIK"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
 ]
 keywords = ["Analytical Inverse Kinematics", "Inverse Kinematics", "Robot Kinematics"]
 dependencies = [
-    'numpy>=1.26.4,<3',
-    'scipy>=1.13,<2',
     'urchin>=0.0.30',
+    'numpy',
+    'scipy',
 ]
 
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,9 @@ classifiers = [
 ]
 keywords = ["Analytical Inverse Kinematics", "Inverse Kinematics", "Robot Kinematics"]
 dependencies = [
-    "numpy >= 1.21.0",
-    "urchin >= 0.0.27",
+    "numpy",
+    "scipy",
+    "urchin"
 ]
 requires-python = ">=3.9"
 version="1.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
 ]
 keywords = ["Analytical Inverse Kinematics", "Inverse Kinematics", "Robot Kinematics"]
 dependencies = [
-    "numpy",
-    "scipy",
-    "urchin"
+    "numpy>=2.4.6,<3",
+    "scipy>=1.17.1,<2",
+    "urchin>=0.0.30",
 ]
 requires-python = ">=3.9"
 version="1.2.1"
@@ -29,7 +29,10 @@ Paper-Preprint = "https://arxiv.org/abs/2409.14815"
 
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
-test-command = "python -c \"import eaik; print('OK')\""
+test-command = """
+python -m pip install --only-binary=:all: numpy scipy urchin
+python -c \"import eaik; print('OK')\"
+"""
 skip = [
     "*-musllinux_*",
     "pp*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,9 @@ classifiers = [
 ]
 keywords = ["Analytical Inverse Kinematics", "Inverse Kinematics", "Robot Kinematics"]
 dependencies = [
-  'numpy>=1.26.4,<3; python_version < "3.11"',
-  'numpy>=2.4.6,<3; python_version >= "3.11"',
-  'scipy>=1.13.1,<2; python_version < "3.11"',
-  'scipy>=1.17.1,<2; python_version >= "3.11"',
-  'urchin>=0.0.30',
+    'numpy>=1.26.4,<3',
+    'scipy>=1.13,<2',
+    'urchin>=0.0.30',
 ]
 
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11", "pybind11-stubgen"]
+requires = ["setuptools>=69", "wheel", "pybind11>=2.10", "pybind11-stubgen"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -17,9 +17,6 @@ keywords = ["Analytical Inverse Kinematics", "Inverse Kinematics", "Robot Kinema
 dependencies = [
     "numpy >= 1.21.0",
     "urchin >= 0.0.27",
-    "setuptools",
-    "pybind11 >= 2.10.0",
-    "pybind11-stubgen >= 0.13.0",
 ]
 requires-python = ">=3.9"
 version="1.2.1"
@@ -28,3 +25,11 @@ version="1.2.1"
 GitHub = "https://github.com/OstermD/EAIK"
 Homepage = "https://ostermd.github.io/EAIK/"
 Paper-Preprint = "https://arxiv.org/abs/2409.14815" 
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+test-command = "python -c \"import eaik; print('OK')\""
+skip = [
+    "*-musllinux_*",
+    "pp*"
+]

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,37 @@
 #!python
 from pybind11.setup_helpers import Pybind11Extension
 from setuptools import setup
+import platform
+
+include_dirs = [
+    "CPP/external/eigen",
+    "CPP/external/ik-geo/cpp/subproblems",
+    "CPP/src/IK",
+    "CPP/src/IK/utils",
+    "CPP/src",
+    "CPP/src/utils",
+]
 
 ext_modules = [
     Pybind11Extension(
         "eaik.pybindings.EAIK",
-        sorted(("src/eaik/pybindings/eaik_pybindings.cpp",
-                "CPP/src/IK/utils/kinematic_utils.cpp",
-                "CPP/src/IK/1R_IK.cpp",
-                "CPP/src/IK/2R_IK.cpp",
-                "CPP/src/IK/3R_IK.cpp",
-                "CPP/src/IK/4R_IK.cpp",
-                "CPP/src/IK/5R_IK.cpp",
-                "CPP/src/IK/6R_IK.cpp",
-                "CPP/src/EAIK.cpp",
-                "CPP/src/utils/kinematic_remodeling.cpp",
-                "CPP/external/ik-geo/cpp/subproblems/sp.cpp")),
-        include_dirs=['CPP/external/ik-geo/cpp/subproblems','CPP/src/IK','CPP/src/IK/utils','CPP/src','CPP/src/utils','/usr/include/eigen3', '/usr/local/include/eigen3'],
-        extra_compile_args=['-std=c++17']
+        sorted((
+            "src/eaik/pybindings/eaik_pybindings.cpp",
+            "CPP/src/IK/utils/kinematic_utils.cpp",
+            "CPP/src/IK/1R_IK.cpp",
+            "CPP/src/IK/2R_IK.cpp",
+            "CPP/src/IK/3R_IK.cpp",
+            "CPP/src/IK/4R_IK.cpp",
+            "CPP/src/IK/5R_IK.cpp",
+            "CPP/src/IK/6R_IK.cpp",
+            "CPP/src/EAIK.cpp",
+            "CPP/src/utils/kinematic_remodeling.cpp",
+            "CPP/external/ik-geo/cpp/subproblems/sp.cpp",
+        )),
+        include_dirs=[str(p) for p in include_dirs],
+        extra_compile_args=["/std:c++17"] if platform.system()=="Windows" else ["-std=c++17"],
     )
 ]
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(ext_modules=ext_modules)


### PR DESCRIPTION
This PR adds Eigen as a submodule and alters the respective include paths.
This enables compilation under Windows and Linux systems where Eigen3.4 is not "installed" in the default directories.
The respective PyPI package is yet to be updated. 
Fixes #29.